### PR TITLE
Migrated everything to use RDD instead of new Dataset type. The reaso…

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,8 +4,10 @@ object Main {
   def main(args: Array[String]) {
 
     val spark = SparkSession.builder.appName("Simple Application").master("local[*]").getOrCreate()
+    val sc = spark.sparkContext
 
-    Preprocessor.readTextFile("twitter_combined.txt", spark).show()
+    val list = Preprocessor.readTextFile("twitter_combined.txt", sc).collect()
+    list.foreach(println(_))
 
     spark.stop()
   }

--- a/src/test/scala/PreprocessorTest.scala
+++ b/src/test/scala/PreprocessorTest.scala
@@ -2,10 +2,10 @@ import org.scalatest.{FunSuite, Matchers}
 
 class PreprocessorTest extends FunSuite
   with Matchers
-  with SparkSessionTestWrapper {
+  with SparkTestWrapper {
 
   test("Read id pairs text file, reverse order and give dataset"){
-    val result = Preprocessor.getDatasetFromText("src/test/samples/sampledata.txt", spark).collect()
+    val result = Preprocessor.getDatasetFromText("src/test/samples/sampledata.txt", sc).collect()
     result.length should equal(6)
     result should contain ("30", "50")
     result should contain ("60", "30")
@@ -16,12 +16,11 @@ class PreprocessorTest extends FunSuite
   }
 
   test("Get dataset of User objects from id pairs of following connections"){
-    import spark.implicits._
-    val idPairs = Seq(("30", "50"), ("60", "30"), ("70", "60"), ("70", "50"), ("60", "50"), ("70", "30")).toDS()
+    val idPairs = sc.parallelize(Seq(("30", "50"), ("60", "30"), ("70", "60"), ("70", "50"), ("60", "50"), ("70", "30")))
 
-    val ds = Preprocessor.getUsersFromPairs(idPairs, spark)
+    val rdd = Preprocessor.getUsersFromPairs(idPairs, sc)
 
-    val result = ds.rdd.collect().sortBy(_.id)
+    val result = rdd.collect().sortBy(_.id)
 
     result.length should equal(3)
     result(0).id should equal("30")

--- a/src/test/scala/SparkTestWrapper.scala
+++ b/src/test/scala/SparkTestWrapper.scala
@@ -1,6 +1,7 @@
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
 
-trait SparkSessionTestWrapper {
+trait SparkTestWrapper {
 
   lazy val spark: SparkSession = {
     SparkSession
@@ -9,5 +10,7 @@ trait SparkSessionTestWrapper {
       .appName("Spark Test")
       .getOrCreate()
   }
+
+  lazy val sc: SparkContext = spark.sparkContext
 
 }


### PR DESCRIPTION
…ning is that Dataset doesn't have encoder even for some simple data types such as Set. So, it is better to use old one.

- All Dataset references changed to RDD.
- SparkContext is used everywhere but SparkSession is still created and SparkContext is taken from it.